### PR TITLE
fix: make setup remote fallback assumes branch

### DIFF
--- a/cms/bin/setup-cms.sh
+++ b/cms/bin/setup-cms.sh
@@ -18,8 +18,7 @@ SRC_ROOT="${SCRIPT_DIR}/../src"
 
 # Configure fallback for settings
 VERSION="main"
-BASE_URL="https://raw.githubusercontent.com/TACC/Core-CMS/refs/tags/${VERSION}"
-# BASE_URL="https://cdn.jsdelivr.net/gh/TACC/Core-CMS@${VERSION}"
+BASE_URL="https://cdn.jsdelivr.net/gh/TACC/Core-CMS@${VERSION}"
 CREATE_VAR_FILES=false
 
 # Functions


### PR DESCRIPTION
## Overview / Changes

Change `make setup` script remote settings URL to CDN one because it works with branch or tag with same URL.

> [!IMPORTANT]
> This does not affect Core-CMS. It only affects https://github.com/TACC/Core-CMS-Template and any repo that newly uses that template.

## Related

- 

## Testing

1. Delete `settings_*.py`
2. Navigate to `/cms`.
3. Run `make setup`.
4. Verify `settings_*.py` has Python content (not "404: Not Found").