### PR TITLE
refactor: forget docker_repo.var

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ https://cep.tacc.utexas.edu/
 > 1. In this doc:
 >    1. Rename "TACC Custom CMS" to the name of this project.
 >    2. Change https://cep.tacc.utexas.edu/ to URL of this project's website.
-> 2. In `.github/workflows/build.yml`:
->    1. Replace `custom-cms` with the name of this project's CMS image.
+> 2. Replace `custom-cms` with the name of this project's CMS image, in:
+>    - `.github/workflows/build.yml`
+>    - `cms/Makefile`
 > 3. Delete `/docs` directory (so it does not become outdated).
 > 4. Follow [Core CMS Template's "Set Up Project"][core-cms-template-setup].
 > 5. Adapt or Remove "[Quick Start](#quick-start)" according to your project.

--- a/cms/Makefile
+++ b/cms/Makefile
@@ -1,4 +1,4 @@
-DOCKERHUB_REPO := $(shell cat ./docker_repo.var)
+DOCKERHUB_REPO := taccwma/custom-cms
 DOCKER_TAG ?= $(shell git rev-parse --short HEAD)
 DOCKER_IMAGE := $(DOCKERHUB_REPO):$(DOCKER_TAG)
 DOCKER_IMAGE_LATEST := $(DOCKERHUB_REPO):latest

--- a/cms/bin/setup-cms.sh
+++ b/cms/bin/setup-cms.sh
@@ -103,25 +103,6 @@ for file in settings_custom settings_local secrets; do
     fi
 done
 
-# Create expected .var files if they don't exist (if enabled)
-if [ "$CREATE_VAR_FILES" = true ]; then
-    echo -e "${INF}Setting up .var files...${RST}"
-    if [ ! -f "needs_demo.var" ]; then
-        echo "false" > needs_demo.var
-        echo -e "  ${POS}Created needs_demo.var${RST}"
-    else
-        echo -e "  ${INF}needs_demo.var already exists${RST}"
-    fi
-    if [ ! -f "docker_repo.var" ]; then
-        echo "core-cms" > docker_repo.var
-        echo -e "  ${POS}Created docker_repo.var${RST}"
-    else
-        echo -e "  ${INF}docker_repo.var already exists${RST}"
-    fi
-else
-    echo -e "${INF}Skipping .var file creation (disabled)${RST}"
-fi
-
 # Build and start Docker containers (from project root)
 echo -e "${INF}Building and starting Docker containers...${RST}"
 cd "$PROJECT_ROOT"


### PR DESCRIPTION
## Overview

Forget `docker_repo.var`. A CMS built from this template would be alone in its repo, so explicitly name example Docker Hub repo.

## Related

- mimics https://github.com/TACC/Core-CMS/pull/966
- similar to https://github.com/TACC/APCD-CMS/pull/18
- similar to https://github.com/TACC/Texascale-CMS/pull/20

## Changes

- **deletes** `docker_repo.var` reference and requirement
- **documents** another `custom-cms` value to change
- **deletes** `.var` steps in `make setup`

## Testing

Run `make setup` and see it does not mention `.var` files but continues to:
> Building and starting Docker containers...

_The only other affected commands are `make build-full`, `make publish`, `make publish-latest`, but we wouldn't run those and a repo created form this template would use GitHub Actions._