### PR TITLE
fix: enforce SILENCED_SYSTEM_CHECKS by default

### DIFF
--- a/cms/src/taccsite_cms/settings_default.py
+++ b/cms/src/taccsite_cms/settings_default.py
@@ -1,0 +1,8 @@
+'''
+A `settings_default.py` file can override default values in `settings.py` before `settings_custom.py`.
+
+This allows Core-CMS client software to standardize their custom settings while still supporting `settings_custom.py` e.g. https://github.com/TACC/Core-Portal/pull/1034.
+'''
+
+# To hide error about using Google Recaptcha test keys
+SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']


### PR DESCRIPTION
## Overview

Add default settings, so missing `settings_*.py` does not cause error.

## Related

- fixes #19
- requires #23

## Changes

- **adds** `settings_default.py`
- **adds** `SILENCED_SYSTEM_CHECKS`

## Testing

0. Comment out https://github.com/TACC/Core-CMS-Template/blob/04f933b2/cms/bin/setup-cms.sh#L82-L104.
1. `make clean`
2. `make setup`
3. Verify no error about `RECAPTCHA_`/`SILENCED_SYSTEM_CHECKS`.
