### PR TITLE
fix: default to SESSION_COOKIE_SECURE False

### DIFF
--- a/cms/src/taccsite_cms/settings_default.py
+++ b/cms/src/taccsite_cms/settings_default.py
@@ -6,3 +6,6 @@ This allows Core-CMS client software to standardize their custom settings while 
 
 # To hide error about using Google Recaptcha test keys
 SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
+
+# To allow http:// access
+SESSION_COOKIE_SECURE = False


### PR DESCRIPTION
## Overview

Add default settings, so local development is not retarded by browser (e.g. Safari) security protocol.

## Related

- fixes #20
- requires #23
- similar to https://github.com/TACC/Core-CMS/pull/1077

## Changes

- **adds** `SESSION_COOKIE_SECURE = False` to `settings_default.py`

## Testing

0. Comment out https://github.com/TACC/Core-CMS-Template/blob/04f933b2/cms/bin/setup-cms.sh#L82-L104.
1. `make clean`
2. `make setup`
3. Open http://localhost:8000 in Safari.
4. Login.

## UI

https://github.com/user-attachments/assets/3cd64f37-d102-4fc1-a97b-3790bd3eda7c

https://github.com/user-attachments/assets/fb77cadc-623a-4ac8-8b77-e180d3ed062b