### PR TITLE
fix: missing settings_default.py support

### DIFF
--- a/cms/docker-compose.dev.yml
+++ b/cms/docker-compose.dev.yml
@@ -11,6 +11,7 @@ services:
       - ./src/taccsite_custom:/code/taccsite_custom
       - ./src/taccsite_cms/custom_app_settings.py:/code/taccsite_cms/custom_app_settings.py
       - ./src/taccsite_cms/urls_custom.py:/code/taccsite_cms/urls_custom.py
+      - ./src/taccsite_cms/settings_default.py:/code/taccsite_cms/settings_default.py
       - ./src/taccsite_cms/settings_custom.py:/code/taccsite_cms/settings_custom.py
       - ./src/taccsite_cms/settings_local.py:/code/taccsite_cms/settings_local.py
       - ./src/taccsite_cms/secrets.py:/code/taccsite_cms/secrets.py


### PR DESCRIPTION
## Overview

Add support for default settings, `settings_default.py` as used when testing #21 and #22.

## Related

- required by #21
- required by #22

## Changes

- **adds** volume for `settings_default.py` in docker container

## Testing

1. `make stop`
2. `make build`
3. `make start`
4. Inspect container.
5. Verify `/code/taccsite_cms/settings_default.py` exists.

Tested during #21 and #22.