### PR TITLE
fix: handle download failure in setup script

### DIFF
--- a/cms/bin/setup-cms.sh
+++ b/cms/bin/setup-cms.sh
@@ -17,28 +17,21 @@ PROJECT_ROOT="${SCRIPT_DIR}/../"
 SRC_ROOT="${SCRIPT_DIR}/../src"
 
 # Configure fallback for settings
-VERSION="main"
+VERSION="stable"
 BASE_URL="https://cdn.jsdelivr.net/gh/TACC/Core-CMS@${VERSION}"
-CREATE_VAR_FILES=false
 
 # Functions
-check_for_curl() {
-    if ! command -v curl &> /dev/null; then
-        echo -e "${NEG}Error: curl is not installed but is required for downloading remote files.${RST}"
-        echo "Please install curl and try again."
-        exit 1
-    fi
-}
 download_file() {
     local url="$1"
     local output_file="$2"
     local description="$3"
 
-    check_for_curl
+    DOWNLOAD_CMD="curl -fL \"$url\" -o \"$output_file\""
 
     echo -e "  ${INF}Downloading ${description}...${RST}"
+    echo -e "  ${DOWNLOAD_CMD}"
 
-    if curl -sL "$url" -o "$output_file"; then
+    if eval $DOWNLOAD_CMD; then
         if [ -s "$output_file" ]; then
             echo -e "  ${POS}Successfully downloaded ${description}${RST}"
             return 0
@@ -48,7 +41,6 @@ download_file() {
             return 1
         fi
     else
-        echo -e "  ${NEG}Error: Failed to download ${description} from ${url}${RST}"
         return 1
     fi
 }
@@ -95,6 +87,12 @@ for file in settings_custom settings_local secrets; do
             echo -e "  ${WRN}Local ${example_file} not found, downloading directly to ${settings_file}...${RST}"
             if ! download_file "$url" "$settings_file" "${file}.py"; then
                 echo -e "${NEG}Error: Failed to download ${settings_file}${RST}"
+                echo -e ""
+                echo -e "  ${WRN}Resolution:${RST}"
+                echo -e "  ${WRN}1. Download file ${url}${RST}"
+                echo -e "  ${WRN}2. Save to ${SRC_ROOT}${settings_file}"
+                echo -e "  ${WRN}3. Re-run this setup script${RST}"
+                echo -e ""
                 exit 1
             fi
         fi


### PR DESCRIPTION
## Overview

Handle download failure gracefully, so user can continue setup after manual steps.

## Related

- fixes #17
- improved by #25

## Changes

- **updates** `bin/setup-cms.sh`

## Testing & UI

### Feature

0. Navigate to `cms/` directory.
1. Delete:
    - `settings_local.py`
    - `settings_custom.py`
    - `secrets.py`
2. `make clean`
3. Change `VERSION="stable"` to `VERSION="some_silly_word"`.
4. `make setup`
5. Verify three downloads fail, and you have steps to resolve.
6. Resolve each failure using step **but use `stable` not `some_silly_word`**.
7. Run `make setup` after each resolution.
8. Verify no related errors.

```sh
~/Code/TACC/Core-CMS-Template (fix/GH-17-cdn-url-download-fail) % cd cms
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % rm -rf src/taccsite_cms/settings_*.py src/taccsite_cms/secrets.py
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % make clean                                             
docker-compose -f docker-compose.dev.yml down -v --rmi all
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % sed -i '' 's/stable/some_silly_word/g' bin/setup-cms.sh          
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % make setup
./bin/setup-cms.sh
Setting up TACC Core CMS...
Checking for required settings files...
  Local taccsite_cms/settings_custom.example.py not found, downloading directly to taccsite_cms/settings_custom.py...
  Downloading settings_custom.py...
  curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/settings_custom.example.py" -o "taccsite_cms/settings_custom.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0    58    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (56) The requested URL returned error: 404
Error: Failed to download taccsite_cms/settings_custom.py

  Resolution:
  1. Download file https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/settings_custom.example.py
  2. Save to /Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../srctaccsite_cms/settings_custom.py
  3. Re-run this setup script

make: *** [setup] Error 1
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@stable/taccsite_cms/settings_custom.example.py" -o "src/taccsite_cms/settings_custom.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3782    0  3782    0     0  25624      0 --:--:-- --:--:-- --:--:-- 25727
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % make setup                                             
./bin/setup-cms.sh
Setting up TACC Core CMS...
Checking for required settings files...
  taccsite_cms/settings_custom.py already exists
  Local taccsite_cms/settings_local.example.py not found, downloading directly to taccsite_cms/settings_local.py...
  Downloading settings_local.py...
  curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/settings_local.example.py" -o "taccsite_cms/settings_local.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (56) The requested URL returned error: 404
Error: Failed to download taccsite_cms/settings_local.py

  Resolution:
  1. Download file https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/settings_local.example.py
  2. Save to /Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../srctaccsite_cms/settings_local.py
  3. Re-run this setup script

make: *** [setup] Error 1
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@stable/taccsite_cms/settings_local.example.py" -o "src/taccsite_cms/settings_local.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1135    0  1135    0     0   1004      0 --:--:--  0:00:01 --:--:--  1005
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % make setup
./bin/setup-cms.sh
Setting up TACC Core CMS...
Checking for required settings files...
  taccsite_cms/settings_custom.py already exists
  taccsite_cms/settings_local.py already exists
  Local taccsite_cms/secrets.example.py not found, downloading directly to taccsite_cms/secrets.py...
  Downloading secrets.py...
  curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/secrets.example.py" -o "taccsite_cms/secrets.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (56) The requested URL returned error: 404
Error: Failed to download taccsite_cms/secrets.py

  Resolution:
  1. Download file https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/secrets.example.py
  2. Save to /Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../srctaccsite_cms/secrets.py
  3. Re-run this setup script

make: *** [setup] Error 1
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@stable/taccsite_cms/secrets.example.py" -o "src/taccsite_cms/secrets.py" 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   847  100   847    0     0   1048      0 --:--:-- --:--:-- --:--:--  1048
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % make setup
     ./bin/setup-cms.sh
 Setting up TACC Core CMS...
    Checking for required settings files...
  taccsite_cms/settings_custom.py already exists
  taccsite_cms/settings_local.py already exists
  taccsite_cms/secrets.py already exists
Building and starting Docker containers...

...
```


### Regression

0. Delete:
    - `settings_local.py`
    - `settings_custom.py`
    - `secrets.py`
1. `make clean`
2. Ensure `VERSION="stable"`.
3. `make setup`
4. Verify no related errors.

```sh
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % rm -rf src/taccsite_cms/settings_*.py src/taccsite_cms/secrets.py
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % make clean
docker-compose -f docker-compose.dev.yml down -v --rmi all
[+] down 9/9

  ...

~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % sed -i '' 's/some_silly_word/stable/g' bin/setup-cms.sh
~/Code/TACC/Core-CMS-Template/cms (fix/GH-17-cdn-url-download-fail) % make setup
./bin/setup-cms.sh
Setting up TACC Core CMS...
Checking for required settings files...
  Local taccsite_cms/settings_custom.example.py not found, downloading directly to taccsite_cms/settings_custom.py...
  Downloading settings_custom.py...
  curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@stable/taccsite_cms/settings_custom.example.py" -o "taccsite_cms/settings_custom.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3782    0  3782    0     0  29188      0 --:--:-- --:--:-- --:--:-- 29317
  Successfully downloaded settings_custom.py
  Local taccsite_cms/settings_local.example.py not found, downloading directly to taccsite_cms/settings_local.py...
  Downloading settings_local.py...
  curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@stable/taccsite_cms/settings_local.example.py" -o "taccsite_cms/settings_local.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1135  100  1135    0     0    884      0  0:00:01  0:00:01 --:--:--   884
  Successfully downloaded settings_local.py
  Local taccsite_cms/secrets.example.py not found, downloading directly to taccsite_cms/secrets.py...
  Downloading secrets.py...
  curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@stable/taccsite_cms/secrets.example.py" -o "taccsite_cms/secrets.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   847  100   847    0     0   1017      0 --:--:-- --:--:-- --:--:--  1016
  Successfully downloaded secrets.py
Building and starting Docker containers...

...
```