### PR TITLE
feat: consolidate dwnload failures of GH-17

### DIFF
--- a/cms/bin/setup-cms.sh
+++ b/cms/bin/setup-cms.sh
@@ -85,7 +85,7 @@ for file in settings_custom settings_local secrets; do
             cp "$example_file" "$settings_file"
         else
             echo -e "  ${WRN}Local ${example_file} not found, downloading directly to ${settings_file}...${RST}"
-            if ! download_file "$url" "$settings_file" "${file}.py"; then
+            if ! download_file "$url" "${SRC_ROOT}/$settings_file" "${file}.py"; then
                 FAILED_DOWNLOADS+=("${file}|${url}|${settings_file}")
             fi
         fi
@@ -101,13 +101,13 @@ if [ ${#FAILED_DOWNLOADS[@]} -gt 0 ]; then
         IFS='|' read -r file url settings_file <<< "$failure"
         echo -e "  ${NEG}✗ ${file}.py${RST}"
         echo -e "    ${INF}URL: ${url}${RST}"
-        echo -e "    ${INF}Save to: ${SRC_ROOT}${settings_file}${RST}"
+        echo -e "    ${INF}Save to: ${SRC_ROOT}/${settings_file}${RST}"
     done
     echo -e ""
     echo -e "${WRN}Resolution:${RST}"
-    echo -e "${WRN}1. Download each file listed above${RST}"
-    echo -e "${WRN}2. Save each file to the corresponding path shown${RST}"
-    echo -e "${WRN}3. Re-run this setup script${RST}"
+    echo -e "${WRN}1. Download each file listed above.${RST}"
+    echo -e "${WRN}2. Save each file to the corresponding path shown.${RST}"
+    echo -e "${WRN}3. Re-run this setup script.${RST}"
     echo -e ""
     exit 1
 fi


### PR DESCRIPTION
## Overview

Consolidate download failures, so user resolve and continue faster.

## Related

- improves #24

## Changes

- **updates** `bin/setup-cms.sh`

## Testing & UI

### Feature

0. Navigate to `cms/` directory.
1. Delete:
    - `settings_local.py`
    - `settings_custom.py`
    - `secrets.py`
2. `make clean`
3. Change `VERSION="stable"` to `VERSION="some_silly_word"`.
4. `make setup`
5. Verify three downloads fail, and you have steps to resolve.
6. Resolve via steps **but use `stable` not `some_silly_word`**.
7. `make setup`
8. Verify no related errors.

```sh
~/Code/TACC/Core-CMS-Template (feat/GH-17-consolidate-download-failures) % cd cms                                                           
~/Code/TACC/Core-CMS-Template/cms (feat/GH-17-consolidate-download-failures) % rm -rf src/taccsite_cms/settings_*.py src/taccsite_cms/secrets.py

~/Code/TACC/Core-CMS-Template/cms (feat/GH-17-consolidate-download-failures) % make clean                                             
docker-compose -f docker-compose.dev.yml down -v --rmi all
~/Code/TACC/Core-CMS-Template/cms (feat/GH-17-consolidate-download-failures) % sed -i '' 's/stable/some_silly_word/g' bin/setup-cms.sh
~/Code/TACC/Core-CMS-Template/cms (feat/GH-17-consolidate-download-failures) % make setup                    
./bin/setup-cms.sh
Setting up TACC Core CMS...
Checking for required settings files...
  Local taccsite_cms/settings_custom.example.py not found, downloading directly to taccsite_cms/settings_custom.py...
  Downloading settings_custom.py...
  curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/settings_custom.example.py" -o "/Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../src/taccsite_cms/settings_custom.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0    58    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (56) The requested URL returned error: 404
  Local taccsite_cms/settings_local.example.py not found, downloading directly to taccsite_cms/settings_local.py...
  Downloading settings_local.py...
  curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/settings_local.example.py" -o "/Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../src/taccsite_cms/settings_local.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0    58    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (56) The requested URL returned error: 404
  Local taccsite_cms/secrets.example.py not found, downloading directly to taccsite_cms/secrets.py...
  Downloading secrets.py...
  curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/secrets.example.py" -o "/Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../src/taccsite_cms/secrets.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0    58    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (56) The requested URL returned error: 404

Failed to download 3 file(s):

  ✗ settings_custom.py
    URL: https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/settings_custom.example.py
    Save to: /Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../src/taccsite_cms/settings_custom.py
  ✗ settings_local.py
    URL: https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/settings_local.example.py
    Save to: /Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../src/taccsite_cms/settings_local.py
  ✗ secrets.py
    URL: https://cdn.jsdelivr.net/gh/TACC/Core-CMS@some_silly_word/taccsite_cms/secrets.example.py
    Save to: /Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../src/taccsite_cms/secrets.py

Resolution:
1. Download each file listed above
2. Save each file to the corresponding path shown
3. Re-run this setup script

make: *** [setup] Error 1
~/Code/TACC/Core-CMS-Template/cms (feat/GH-17-consolidate-download-failures) % curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@stable/taccsite_cms/settings_custom.example.py" -o "/Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../src/taccsite_cms/settings_custom.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3782    0  3782    0     0  25122      0 --:--:-- --:--:-- --:--:-- 25213
~/Code/TACC/Core-CMS-Template/cms (feat/GH-17-consolidate-download-failures) % curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@stable/taccsite_cms/settings_local.example.py" -o "/Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../src/taccsite_cms/settings_local.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1135  100  1135    0     0  12032      0 --:--:-- --:--:-- --:--:-- 12074
~/Code/TACC/Core-CMS-Template/cms (feat/GH-17-consolidate-download-failures) % curl -fL "https://cdn.jsdelivr.net/gh/TACC/Core-CMS@stable/taccsite_cms/secrets.example.py" -o "/Users/wbomar/Code/TACC/Core-CMS-Template/cms/bin/../src/taccsite_cms/secrets.py"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   847  100   847    0     0   7543      0 --:--:-- --:--:-- --:--:--  7562
~/Code/TACC/Core-CMS-Template/cms (feat/GH-17-consolidate-download-failures) % make setup
./bin/setup-cms.sh
Setting up TACC Core CMS...
Checking for required settings files...
  taccsite_cms/settings_custom.py already exists
  taccsite_cms/settings_local.py already exists
  taccsite_cms/secrets.py already exists
Building and starting Docker containers...
```